### PR TITLE
Add react-map-gl to supporting projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ A collection of awesome things that use or support MapLibre!
 
 ## Other Official Projects
 - [MapLibre Demotiles](https://github.com/maplibre/demotiles)
+
+## Projects Supporting MapLibre
+
+- [react-map-gl](https://visgl.github.io/react-map-gl/docs)


### PR DESCRIPTION
Thankfully react-map-gl and by extension deck.gl support MapLibre GL. Should I add deck.gl to the list as well?