### PR TITLE
Update README.md with link to Terra Draw

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ https://github.com/m0nac0/flutter-maplibre-gl
 - [ol-maplibre-layer](https://github.com/geoblocks/ol-maplibre-layer) - Render a MapLibre GL JS map as an [OpenLayers](https://openlayers.org/) layer.
 - [maplibre-gl-measures](https://github.com/jdsantos/maplibre-gl-measures) - A plugin for taking measures on the map.
 - [maplibre-contour](https://github.com/onthegomap/maplibre-contour) - Renders contour lines from raster DEM tiles in MapLibre GL JS.
+- [Terra Draw](https://www.github.com/JamesLMilner/terra-draw) - The library has a MapLibre GL JS adapter to provide drawing and geometry editing functionality to the map
 
 ## Utilities
 


### PR DESCRIPTION
Adds Terra Draw as a optional library that you can use with MapLibre GL JS.