### PR TITLE
add maplibre-theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ A collection of awesome things that use or support [MapLibre](https://maplibre.o
 - [Headless Node Renderer](https://github.com/ConservationMetrics/mapgl-tile-renderer) - Headless Node.js MapGL renderer for generating MBTiles with styled raster tiles.
 - [MapBlockly](https://mapblockly.github.io/) - MapBlockly is a simple and fun way to learn and build Map with Blockly using MapLibre.
 - [MapInventor](https://mapinventor.github.io/) - MapInventor is the visual language built on top of MapBlockly.
+- [Theme](https://github.com/lhapaipai/maplibre-theme) - Custom themes for your MapLibre GL Js Web app. [demo](https://maplibre-theme.pentatrion.com/)
 
 ## Sprites
 


### PR DESCRIPTION
Hi,

This repos contain css for themes who are designed to mimic the actual theme with some improvements.

- light : actually 20ko-30ko minified
- support dark mode
- support CSS variables for easy optimisation.
- 
if this interests you for the community you can include it in the listing