### PR TITLE
add chiitiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ A collection of awesome things that use or support [MapLibre](https://maplibre.o
 - [MapInventor](https://mapinventor.github.io/) - MapInventor is the visual language built on top of MapBlockly.
 - [Theme](https://github.com/lhapaipai/maplibre-theme) - Custom themes for your MapLibre GL Js Web app. [demo](https://maplibre-theme.pentatrion.com/)
 - [MapLibre VSCode Extension](https://github.com/Kanahiro/maplibre-vscode-extension) - VSCode Extension for viewing/editing MapLibre Style.
+- [chiitiler](https://github.com/Kanahiro/chiitiler) - chiitiler - "Tiny MapLibre Server" is alternative to TileserverGL, designed to runs on serverless infrastructures. [demo](https://spatialty-io.github.io/chiitiler-demo/)
 
 ## Sprites
 


### PR DESCRIPTION
Hi,

Added [Kanahiro/chiitiler](https://github.com/Kanahiro/chiitiler) to the list.
chiitiler is raster tile server alternative to TileserverGL, you can see [demo](https://spatialty-io.github.io/chiitiler-demo/?stylename=gsi-std#9.63/35.5524/140.0656).
If okay, please merge this change.