### PR TITLE
add maplibre-react-components

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A collection of awesome things that use or support [MapLibre](https://maplibre.o
 
 - [react-map-gl](https://visgl.github.io/react-map-gl/docs/get-started#using-with-a-compatible-fork)
 - [react-map-components-maplibre](https://github.com/mapcomponents/react-map-components-maplibre) - A React component framework for declarative GIS application development with demos in their [showcase](https://catalogue.mapcomponents.org/) and [docs](https://mapcomponents.github.io/react-map-components-maplibre)
+- [maplibre-react-components](https://maplibre-react-components.pentatrion.com/) - Lightweight MapLibre only binding for React.
 
 #### Svelte
 


### PR DESCRIPTION
Hello every one,
I would like to propose this library for react.

I realize that it is better to join efforts and avoid creating multiple projects.

However, I had 2 problems with the existing libraries.
`react-map-gl` is compatible with MapLibre **and** MapBox, which adds an additional abstraction in all of his code base and may cause problems in the long term when the 2 projects diverge more.

react-map-components-maplibre is a framework with a lot of features, and a ton of dependencies: `mui`, `emotion`, `jspdf`, `react-color`, `d3`, `three`. a simple hello Map adds 700 kB of code which can be a problem for very small projects.

So I think that this project could be suitable for some projects because it is very light (about 30kB) and only compatible with MapLibre, therefore as close as possible to its typing and its features.

It's up to you to decide...
Have a good evening
