### PR TITLE
Add a few more projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,22 @@ are designated with a ✅, and hosted projects with a 💙.
 
 ## Bindings
 
-###  Mobile
+### Flutter
 
 - 💙 [flutter-maplibre-gl](https://github.com/maplibre/flutter-maplibre-gl) - Bindings for Flutter on Android, iOS and Web, on pub.dev at [pub.dev/packages/maplibre_gl](https://pub.dev/packages/maplibre_gl)
+
+### React Native
+
 - 💙 [MapLibre React Native](https://github.com/maplibre/maplibre-react-native) - A MapLibre module for React Native (including Expo support).
+
+### SwiftUI
+
 - 💙 [MapLibre SwiftUI DSL](https://github.com/maplibre/swiftui-dsl) - A Swift package bridging the gap between MapLibre Native and SwiftUI with MapKit-like ease of use.
+
+### Jetpack Compose
+
 - [Ramani Maps](https://github.com/ramani-maps/ramani-maps) - A Jetpack Compose library to manipulate maps on Android.
-- [MapLibre Compose Playground](https://github.com/Rallista/maplibre-compose-playground) - A Jetpack Compose library that takes inspiration from Ramani, but leans towards API similarity with the SwiftUI DSL and de-emphasizes drawing/editing .
+- [MapLibre Compose Playground](https://github.com/Rallista/maplibre-compose-playground) - A Jetpack Compose library that takes inspiration from Ramani, but leans towards API similarity with the SwiftUI DSL and de-emphasizes drawing/editing.
 
 ### Python
 
@@ -126,6 +135,7 @@ are designated with a ✅, and hosted projects with a 💙.
 <!-- [JAVASCRIPT-PLUGINS]:BEGIN -->
 ## User Interface Plugins
 
+- 💙 [maplibre-gl-compare](https://github.com/maplibre/maplibre-gl-compare) - Enables users to compare two maps by swiping left and right.
 - [any-routing](https://github.com/marucjmar/any-routing) - A modular plugin for calculating routes.
 - [Gauge Legend](https://github.com/AbelVM/gauge_legend) - Dynamic gauge legend for MapLibre GL JS
 - [mapbox-gl-controls](https://github.com/bravecow/mapbox-gl-controls) - Adds controls for a ruler, style inspector, localization, and style switcher.
@@ -138,7 +148,6 @@ are designated with a ✅, and hosted projects with a 💙.
 - [maplibre-compass-pro](https://github.com/jedluk/maplibre-compass-pro) - old fashioned compass (with compass rose) for Maplibre GL. [demo](https://codesandbox.io/p/sandbox/peaceful-mirzakhani-tv38ck)
 - [maplibre-preload](https://github.com/AbelVM/maplibre-preload) - A tiny zero-configuration plugin for preloading tiles and smoothen the experience when using targeted movements in MapLibre GL JS.
 - [maplibre-gl-basemaps](https://github.com/ka7eh/maplibre-gl-basemaps) - A plugin for switching between raster basemaps.
-- 💙 [maplibre-gl-compare](https://github.com/maplibre/maplibre-gl-compare) - Enables users to compare two maps by swiping left and right.
 - [maplibre-gl-export](https://github.com/watergis/maplibre-gl-export) - Adds a control that exports the map as a PDF or images such as PNG, JPEG and SVG.
 - [maplibre-gl-measures](https://github.com/jdsantos/maplibre-gl-measures) - A plugin for taking measures on the map.
 - [maplibre-gl-opacity](https://github.com/mug-jp/maplibre-gl-opacity) - A plugin to switch layer like Leaflet.control.layers, and update opacities. [demo](https://mug-jp.github.io/maplibre-gl-opacity/)
@@ -156,6 +165,7 @@ are designated with a ✅, and hosted projects with a 💙.
 
 ## Map Rendering Plugins
 
+- 💙 [MapLibre GL Leaflet](https://github.com/maplibre/maplibre-gl-leaflet) - A plugin for rendering MapLibre styles in [Leaflet](https://leafletjs.com).
 - [deck.gl](https://github.com/visgl/deck.gl) - Adds advanced WebGL visualization layers.
 - [flowmap.blue](https://github.com/ilyabo/flowmap.blue) - Render a geographic flow map visualization from a spreadsheet published on Google Sheets.
 - [H3J / H3T](https://github.com/INSPIDE/h3j-h3t) - Light [H3](https://h3geo.org/) data formats for client side geometry generation and rendering using MapLibre GL JS
@@ -166,7 +176,6 @@ are designated with a ✅, and hosted projects with a 💙.
 - [maplibre-contour](https://github.com/onthegomap/maplibre-contour) - Renders contour lines from raster DEM tiles in MapLibre GL JS.
 - [maplibre-gl-dates](https://github.com/OpenHistoricalMap/maplibre-gl-dates/) – Filters a time-enabled map by date. Optimized for OpenHistoricalMap vector tiles.
 - [maplibre-gl-vector-text-protocol](https://github.com/jimmyrocks/maplibre-gl-vector-text-protocol) - Supports `CSV`, `TSV`, `Topojson`, `KML`, `GPX`, and `TCX` formats using the addProtocol feature.
-- 💙 [MapLibre GL Leaflet](https://github.com/maplibre/maplibre-gl-leaflet) - A plugin for rendering MapLibre styles in [Leaflet](https://leafletjs.com).
 
 
 ## Layer Types Plugins
@@ -203,6 +212,7 @@ are designated with a ✅, and hosted projects with a 💙.
 
 ## Map/Tile Providers
 
+- 💙 [MapLibre Demotiles](https://github.com/maplibre/demotiles) - A simple, XYZ MVT tileset for demonstration projects.
 - [**Amazon Location Services**](https://aws.amazon.com/location/)
 - [**Azure Maps**](https://azure.microsoft.com/en-us/products/azure-maps)
 - [Esri](https://developers.arcgis.com/maplibre-gl-js/)
@@ -211,7 +221,6 @@ are designated with a ✅, and hosted projects with a 💙.
 - [HERE](https://www.here.com/docs/bundle/vector-tile-api-developer-guide/page/README.html)
 - [**JawgMaps**](https://www.jawg.io/)
 - [Mapbox](https://www.mapbox.com/)
-- 💙 [MapLibre Demotiles](https://github.com/maplibre/demotiles) - A simple, XYZ MVT tileset for demonstration projects.
 - [MapTiler](https://www.maptiler.com/)
 - [**Mierune**](https://www.mierune.co.jp/?lang=en)
 - [OpenFreeMap](https://openfreemap.org/)
@@ -222,11 +231,12 @@ are designated with a ✅, and hosted projects with a 💙.
 
 **In bold**: Members of the [MapLibre Sponsorship Program](https://maplibre.org/sponsors/)
 
-## Map Tile Generators
+## Tile Servers
 
 - 💙 [Martin](https://github.com/maplibre/martin) - A PostGIS, MBtiles and PMtiles tile server, supports tile generation and mbtiles tooling.
 - [Headless Node Renderer](https://github.com/ConservationMetrics/mapgl-tile-renderer) - Headless Node.js MapGL renderer for generating MBTiles with styled raster tiles.
-- [chiitiler](https://github.com/Kanahiro/chiitiler) - chiitiler - "Tiny MapLibre Server" is alternative to TileserverGL, designed to runs on serverless infrastructures. [demo](https://spatialty-io.github.io/chiitiler-demo/)
+- [chiitiler](https://github.com/Kanahiro/chiitiler) - chiitiler - "Tiny MapLibre Server" is alternative to Tileserver GL, designed to runs on serverless infrastructures. [demo](https://spatialty-io.github.io/chiitiler-demo/)
+- [TileServer GL](https://github.com/maptiler/tileserver-gl) - Vector tile server from MBTiles archives + server-side rasterizing with MapLibre GL native.
 
 ## Utilities
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ are designated with a ✅, and hosted projects with a 💙.
 
 **In bold**: Members of the [MapLibre Sponsorship Program](https://maplibre.org/sponsors/)
 
-## Map Tile generation
+## Map Tile Generators
 
 - 💙 [Martin](https://github.com/maplibre/martin) - A PostGIS, MBtiles and PMtiles tile server, supports tile generation and mbtiles tooling.
 - [Headless Node Renderer](https://github.com/ConservationMetrics/mapgl-tile-renderer) - Headless Node.js MapGL renderer for generating MBTiles with styled raster tiles.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A collection of awesome things that use or support [MapLibre](https://maplibre.o
 - [Martin](https://github.com/maplibre/martin) - A PostGIS, MBtiles and PMtiles tile server, supports tile generation and mbtiles tooling.
 - [MapLibre RS](https://github.com/maplibre/maplibre-rs) - Experimental map rendering library written in Rust.
 - [MapLibre Plugins for Android](https://github.com/maplibre/maplibre-plugins-android) - A collection of plugins for MapLibre on Android.
+- [MapLibre SwiftUI DSL](https://github.com/maplibre/swiftui-dsl) - A Swift package bridging the gap between MapLibre Native and SwiftUI with MapKit-like ease of use.
 - [MapLibre Navigation SDK for Android](https://github.com/maplibre/maplibre-navigation-android)
 - [MapLibre GL Directions](https://github.com/maplibre/maplibre-gl-directions) - A plugin to show routing directions on a MapLibre GL JS map
 
@@ -205,6 +206,7 @@ A collection of awesome things that use or support [MapLibre](https://maplibre.o
 - [Theme](https://github.com/lhapaipai/maplibre-theme) - Custom themes for your MapLibre GL Js Web app. [demo](https://maplibre-theme.pentatrion.com/)
 - [MapLibre VSCode Extension](https://github.com/Kanahiro/maplibre-vscode-extension) - VSCode Extension for viewing/editing MapLibre Style.
 - [chiitiler](https://github.com/Kanahiro/chiitiler) - chiitiler - "Tiny MapLibre Server" is alternative to TileserverGL, designed to runs on serverless infrastructures. [demo](https://spatialty-io.github.io/chiitiler-demo/)
+- [SDF Font Tools](https://github.com/stadiamaps/sdf_font_tools) - A CLI tool for generating SDF fontstacks from fonts (similar to FontMaker), as well as crates which let you build fontstacks on the fly (used in MapLibre Martin).
 
 ## Sprites
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ are designated with a ✅, and hosted projects with a 💙.
 ### Flutter
 
 - 💙 [flutter-maplibre-gl](https://github.com/maplibre/flutter-maplibre-gl) - Bindings for Flutter on Android, iOS and Web, on pub.dev at [pub.dev/packages/maplibre_gl](https://pub.dev/packages/maplibre_gl)
+- [flutter-maplibre](https://github.com/josxha/flutter-maplibre) - A fresh, modern take on Flutter bindings for MapLibre Native.
 
 ### React Native
 

--- a/README.md
+++ b/README.md
@@ -4,32 +4,54 @@
 
 A collection of awesome things that use or support [MapLibre](https://maplibre.org)!
 
-## Official Projects
+MapLibre [Core projects](https://github.com/maplibre/maplibre/blob/main/PROJECT_TIERS.md)
+are designated with a ✅, and hosted projects with a 💙.
 
-### Offical Rendering Projects
 
-- [MapLibre GL JS](https://github.com/maplibre/maplibre-gl-js) - A map SDK for rendering maps on the Web.
-- [MapLibre Native](https://github.com/maplibre/maplibre-gl-native) - A maps SDK for rendering maps on devices, in apps, and on the server.
+## Map Rendering
 
-### Other Official Projects
+- ✅ [MapLibre GL JS](https://github.com/maplibre/maplibre-gl-js) - A map SDK for rendering maps on the Web.
+- ✅ [MapLibre Native](https://github.com/maplibre/maplibre-gl-native) - A maps SDK for rendering maps on devices, in apps, and on the server.
+- 💙 [MapLibre RS](https://github.com/maplibre/maplibre-rs) - Experimental map rendering library written in Rust.
+- ✅ [MapLibre Plugins for Android](https://github.com/maplibre/maplibre-plugins-android) - A collection of plugins for MapLibre on Android; the annotation plugin is a core project.
 
-- [MapLibre style specification](https://github.com/maplibre/maplibre-style-spec) - The MapLibre Style Specification, a JSON-based format for styling maps.
-- [Maputnik](https://github.com/maplibre/maputnik) - A visual style editor for MapLibre GL JS. Hosted at [maplibre.org/maputnik](https://maplibre.org/maputnik)
-- [MapLibre GL Leaflet](https://github.com/maplibre/maplibre-gl-leaflet) - A plugin for rendering MapLibre styles in [Leaflet](https://leafletjs.com).
-- [MapLibre Demotiles](https://github.com/maplibre/demotiles) - A simple, XYZ MVT tileset for demonstration projects.
-- [Martin](https://github.com/maplibre/martin) - A PostGIS, MBtiles and PMtiles tile server, supports tile generation and mbtiles tooling.
-- [MapLibre RS](https://github.com/maplibre/maplibre-rs) - Experimental map rendering library written in Rust.
-- [MapLibre Plugins for Android](https://github.com/maplibre/maplibre-plugins-android) - A collection of plugins for MapLibre on Android.
-- [MapLibre SwiftUI DSL](https://github.com/maplibre/swiftui-dsl) - A Swift package bridging the gap between MapLibre Native and SwiftUI with MapKit-like ease of use.
-- [MapLibre Navigation SDK for Android](https://github.com/maplibre/maplibre-navigation-android)
-- [MapLibre GL Directions](https://github.com/maplibre/maplibre-gl-directions) - A plugin to show routing directions on a MapLibre GL JS map
+## Map Styling
+
+- ✅ [MapLibre style specification](https://github.com/maplibre/maplibre-style-spec) - The MapLibre Style Specification, a JSON-based format for styling maps.
+
+### Style Editors
+
+- 💙 [Maputnik](https://github.com/maplibre/maputnik) - A visual style editor for MapLibre GL JS. Hosted at [maplibre.org/maputnik](https://maplibre.org/maputnik)
+- [Theme](https://github.com/lhapaipai/maplibre-theme) - Custom themes for your MapLibre GL Js Web app. [demo](https://maplibre-theme.pentatrion.com/)
+- [MapLibre VSCode Extension](https://github.com/Kanahiro/maplibre-vscode-extension) - VSCode Extension for viewing/editing MapLibre Style.
+
+### Font Glyph Generation
+
+- 💙 [Font Maker](https://github.com/maplibre/font-maker) - web app to convert font files into SDF fontstacks for use in MapLibre.
+- [SDF Font Tools](https://github.com/stadiamaps/sdf_font_tools) - A CLI tool for generating SDF fontstacks from fonts (similar to FontMaker), as well as crates which let you build fontstacks on the fly (used in MapLibre Martin).
+
+### Sprite Generation
+
+- [Spreet](https://github.com/flother/spreet) - Spreet is a command-line tool that creates a spritesheet (aka texture atlas) from a directory of SVG images.
+- [Figmasset](https://github.com/stamen/figmasset) - Figmasset is a tool to facilitate bulk-loading assets from Figma into a JavaScript application.
+- [Sprite One](https://www.npmjs.com/package/@unvt/sprite-one) - Generate sprite image and json without Mapnik.
+
+## Navigation & Directions
+
+- 💙 [MapLibre Navigation SDK for iOS](https://github.com/maplibre/maplibre-navigation-ios) - Turn-by-turn navigation built on MapLibre; a FOSS fork of Mapbox Navigation
+- 💙 [MapLibre Navigation SDK for Android](https://github.com/maplibre/maplibre-navigation-android) - Turn-by-turn navigation built on MapLibre; a FOSS fork of Mapbox Navigation
+- 💙 [MapLibre GL Directions](https://github.com/maplibre/maplibre-gl-directions) - A plugin to show routing directions on a MapLibre GL JS map
+- [Ferrostar](https://github.com/stadiamaps/ferrostar) - A turn-by-turn navigation SDK built from the ground up using MapLibre on iOS, Android, and the web.
 
 ## Bindings
 
+###  Mobile
 
-### Flutter (Dart)
-
-- [flutter-maplibre-gl](https://github.com/maplibre/flutter-maplibre-gl) - Bindings for Flutter on Android, iOS and Web, on pub.dev at [pub.dev/packages/maplibre_gl](https://pub.dev/packages/maplibre_gl)
+- 💙 [flutter-maplibre-gl](https://github.com/maplibre/flutter-maplibre-gl) - Bindings for Flutter on Android, iOS and Web, on pub.dev at [pub.dev/packages/maplibre_gl](https://pub.dev/packages/maplibre_gl)
+- 💙 [MapLibre React Native](https://github.com/maplibre/maplibre-react-native) - A MapLibre module for React Native (including Expo support).
+- 💙 [MapLibre SwiftUI DSL](https://github.com/maplibre/swiftui-dsl) - A Swift package bridging the gap between MapLibre Native and SwiftUI with MapKit-like ease of use.
+- [Ramani Maps](https://github.com/ramani-maps/ramani-maps) - A Jetpack Compose library to manipulate maps on Android.
+- [MapLibre Compose Playground](https://github.com/Rallista/maplibre-compose-playground) - A Jetpack Compose library that takes inspiration from Ramani, but leans towards API similarity with the SwiftUI DSL and de-emphasizes drawing/editing .
 
 ### Python
 
@@ -39,7 +61,7 @@ A collection of awesome things that use or support [MapLibre](https://maplibre.o
 
 ### Qt (C++)
 
-- [maplibre-native-qt](https://github.com/maplibre/maplibre-native-qt) - MapLibre Native Qt bindings and Qt Location MapLibre Plugin
+- 💙 [maplibre-native-qt](https://github.com/maplibre/maplibre-native-qt) - MapLibre Native Qt bindings and Qt Location MapLibre Plugin
 
 ### R
 
@@ -51,7 +73,7 @@ A collection of awesome things that use or support [MapLibre](https://maplibre.o
 
 #### [Angular](https://angular.dev/)
 
-- [ngx-maplibre-gl](https://github.com/maplibre/ngx-maplibre-gl) - Angular binding with hosted demos at [maplibre.org/ngx-maplibre-gl/demo](https://maplibre.org/ngx-maplibre-gl/demo/)
+- 💙 [ngx-maplibre-gl](https://github.com/maplibre/ngx-maplibre-gl) - Angular binding with hosted demos at [maplibre.org/ngx-maplibre-gl/demo](https://maplibre.org/ngx-maplibre-gl/demo/)
 
 #### [Astro](https://astro.build)
 
@@ -95,6 +117,7 @@ A collection of awesome things that use or support [MapLibre](https://maplibre.o
 - [wtMapbox](https://github.com/yvanvds/wtMapbox) - Provides a Webtoolkit integration.
 
 #### Vanilla JS
+
 - [plotly.js](https://plotly.com/javascript/maps/) - Create analytical geospatial figures with MapLibre GL JS in javascript.
 
 <!-- [JAVASCRIPT-BINDINGS]:END -->
@@ -115,7 +138,7 @@ A collection of awesome things that use or support [MapLibre](https://maplibre.o
 - [maplibre-compass-pro](https://github.com/jedluk/maplibre-compass-pro) - old fashioned compass (with compass rose) for Maplibre GL. [demo](https://codesandbox.io/p/sandbox/peaceful-mirzakhani-tv38ck)
 - [maplibre-preload](https://github.com/AbelVM/maplibre-preload) - A tiny zero-configuration plugin for preloading tiles and smoothen the experience when using targeted movements in MapLibre GL JS.
 - [maplibre-gl-basemaps](https://github.com/ka7eh/maplibre-gl-basemaps) - A plugin for switching between raster basemaps.
-- [maplibre-gl-compare](https://github.com/maplibre/maplibre-gl-compare) - Enables users to compare two maps by swiping left and right.
+- 💙 [maplibre-gl-compare](https://github.com/maplibre/maplibre-gl-compare) - Enables users to compare two maps by swiping left and right.
 - [maplibre-gl-export](https://github.com/watergis/maplibre-gl-export) - Adds a control that exports the map as a PDF or images such as PNG, JPEG and SVG.
 - [maplibre-gl-measures](https://github.com/jdsantos/maplibre-gl-measures) - A plugin for taking measures on the map.
 - [maplibre-gl-opacity](https://github.com/mug-jp/maplibre-gl-opacity) - A plugin to switch layer like Leaflet.control.layers, and update opacities. [demo](https://mug-jp.github.io/maplibre-gl-opacity/)
@@ -126,7 +149,7 @@ A collection of awesome things that use or support [MapLibre](https://maplibre.o
 
 ## Geocoding & Search Plugins
 - [mapbox.photon](https://github.com/watergis/mapbox.photon) - Adds a control to provide a geocoding feature from Photon API.
-- [maplibre-gl-geocoder](https://github.com/maplibre/maplibre-gl-geocoder) - Adds a geocoder control.
+- 💙 [maplibre-gl-geocoder](https://github.com/maplibre/maplibre-gl-geocoder) - Adds a geocoder control.
 - [maplibre-search-box](https://github.com/stadiamaps/maplibre-search-box) - Adds a control for searching for places using Stadia Maps.
 - [maptiler-geocoding-control](https://github.com/maptiler/maptiler-geocoding-control) - Adds a geocoding control for searching for places using MapTiler API. [docs](https://docs.maptiler.com/sdk-js/modules/geocoding/)
 
@@ -143,6 +166,7 @@ A collection of awesome things that use or support [MapLibre](https://maplibre.o
 - [maplibre-contour](https://github.com/onthegomap/maplibre-contour) - Renders contour lines from raster DEM tiles in MapLibre GL JS.
 - [maplibre-gl-dates](https://github.com/OpenHistoricalMap/maplibre-gl-dates/) – Filters a time-enabled map by date. Optimized for OpenHistoricalMap vector tiles.
 - [maplibre-gl-vector-text-protocol](https://github.com/jimmyrocks/maplibre-gl-vector-text-protocol) - Supports `CSV`, `TSV`, `Topojson`, `KML`, `GPX`, and `TCX` formats using the addProtocol feature.
+- 💙 [MapLibre GL Leaflet](https://github.com/maplibre/maplibre-gl-leaflet) - A plugin for rendering MapLibre styles in [Leaflet](https://leafletjs.com).
 
 
 ## Layer Types Plugins
@@ -187,8 +211,9 @@ A collection of awesome things that use or support [MapLibre](https://maplibre.o
 - [HERE](https://www.here.com/docs/bundle/vector-tile-api-developer-guide/page/README.html)
 - [**JawgMaps**](https://www.jawg.io/)
 - [Mapbox](https://www.mapbox.com/)
+- 💙 [MapLibre Demotiles](https://github.com/maplibre/demotiles) - A simple, XYZ MVT tileset for demonstration projects.
 - [MapTiler](https://www.maptiler.com/)
-- [Mierune](https://www.mierune.co.jp/?lang=en)
+- [**Mierune**](https://www.mierune.co.jp/?lang=en)
 - [OpenFreeMap](https://openfreemap.org/)
 - [OSM Americana Community Vector Tile Server](https://tile.ourmap.us/)
 - [Protomaps](https://protomaps.com/)
@@ -197,22 +222,17 @@ A collection of awesome things that use or support [MapLibre](https://maplibre.o
 
 **In bold**: Members of the [MapLibre Sponsorship Program](https://maplibre.org/sponsors/)
 
+## Map Tile generation
+
+- 💙 [Martin](https://github.com/maplibre/martin) - A PostGIS, MBtiles and PMtiles tile server, supports tile generation and mbtiles tooling.
+- [Headless Node Renderer](https://github.com/ConservationMetrics/mapgl-tile-renderer) - Headless Node.js MapGL renderer for generating MBTiles with styled raster tiles.
+- [chiitiler](https://github.com/Kanahiro/chiitiler) - chiitiler - "Tiny MapLibre Server" is alternative to TileserverGL, designed to runs on serverless infrastructures. [demo](https://spatialty-io.github.io/chiitiler-demo/)
+
 ## Utilities
 
-- [Font Maker](https://github.com/maplibre/font-maker) - web app to convert font files into SDF fontstacks for use in MapLibre.
-- [Headless Node Renderer](https://github.com/ConservationMetrics/mapgl-tile-renderer) - Headless Node.js MapGL renderer for generating MBTiles with styled raster tiles.
 - [MapBlockly](https://mapblockly.github.io/) - MapBlockly is a simple and fun way to learn and build Map with Blockly using MapLibre.
 - [MapInventor](https://mapinventor.github.io/) - MapInventor is the visual language built on top of MapBlockly.
-- [Theme](https://github.com/lhapaipai/maplibre-theme) - Custom themes for your MapLibre GL Js Web app. [demo](https://maplibre-theme.pentatrion.com/)
-- [MapLibre VSCode Extension](https://github.com/Kanahiro/maplibre-vscode-extension) - VSCode Extension for viewing/editing MapLibre Style.
-- [chiitiler](https://github.com/Kanahiro/chiitiler) - chiitiler - "Tiny MapLibre Server" is alternative to TileserverGL, designed to runs on serverless infrastructures. [demo](https://spatialty-io.github.io/chiitiler-demo/)
-- [SDF Font Tools](https://github.com/stadiamaps/sdf_font_tools) - A CLI tool for generating SDF fontstacks from fonts (similar to FontMaker), as well as crates which let you build fontstacks on the fly (used in MapLibre Martin).
-
-## Sprites
-
-- [Spreet](https://github.com/flother/spreet) - Spreet is a command-line tool that creates a spritesheet (aka texture atlas) from a directory of SVG images.
-- [Figmasset](https://github.com/stamen/figmasset) - Figmasset is a tool to facilitate bulk-loading assets from Figma into a JavaScript application.
-- [Sprite One](https://www.npmjs.com/package/@unvt/sprite-one) - Generate sprite image and json without Mapnik.
+- [Overpass Ultra](https://overpass-ultra.us/) - A mashup between the Overpass API and MapLibre styling.
 
 ## Users
 


### PR DESCRIPTION
Adding a few more here. I have a few other things we should add too, but wanted to start a discussion first on organization.

The "other official projects" designation is quite confusing. For example, it includes MapLibre Navigation Android, but the Qt and Flutter packages are listed under bindings. So it's not particularly clear where the SwiftUI DSL should end up ;) (I also noticed that the iOS Navigation SDK is missing too, but will add that after we resolve the discussion points below.)

A few ideas:

1. If we are OK repeating items, it might make sense to put both these under multiple headings, as they are all (AFAIK) "official" projects, but that is not particularly useful for discovery groupings. I'm also not sure (this is a really subjective view) if "bindings" is even a very helpful heading. Browsers probably care more about "what are ways that I can use MapLibre and <Technology X>." So, for a concrete suggestion, we could have categories for iOS, Qt, and Android. Projects could be listed in multiple categories then for better discoverability. This would also make more logical points where associated/deeply integrated libraries, such as Ferrostar, can fit in (ex: we could have categories for iOS, Android, and Turn-by-Turn Navigation).
2. If we don't want to repeat items, I'm not exactly sure what to do. I personally find the "other official projects" label not super helpful so I'd lean toward breaking up that list and putting items into other categories. In this scenario, it may still be useful though to highlight which projects are "official." I propose we could do that with an emoji or something with an explainer at the top. For example, ⭐? This gets into the second confusion though with what constitutes "official." Maybe we should differentiate between the projects with monetary support and the hosted ones?

Anyways, thanks for reading and I hope the ensuing discussion makes this list more awesome :) 