### PR TITLE
docs(vue): add libregl package

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ are designated with a ✅, and hosted projects with a 💙.
 #### [VueJS](https://vuejs.org/)
 
 - [@indoorequal/vue-maplibre-gl](https://github.com/indoorequal/vue-maplibre-gl) - Vue 3 plugin for maplibre-gl-js
+- [LibreGL](https://github.com/themustafaomar/libregl) - A powerful Vue library for Maplibre with an intuitive API, and a collection of highly customizable components.
 
 #### [Webtoolkit](https://www.webtoolkit.eu/wt)
 


### PR DESCRIPTION
Hi,

I've just released LibreGL a modern Vue plugin for integrating MapLibre into Vue apps, and I think it may be helpful for the community.

Github repo: https://github.com/themustafaomar/libregl

It has an awesome docs: https://libregl.vercel.app

And demo: https://stackblitz.com/edit/libregl
