### PR TITLE
Add Compose Multiplatform wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ are designated with a ✅, and hosted projects with a 💙.
 - [Ramani Maps](https://github.com/ramani-maps/ramani-maps) - A Jetpack Compose library to manipulate maps on Android.
 - [MapLibre Compose Playground](https://github.com/Rallista/maplibre-compose-playground) - A Jetpack Compose library that takes inspiration from Ramani, but leans towards API similarity with the SwiftUI DSL and de-emphasizes drawing/editing.
 
+### Compose Multiplatform
+
+- [MapLibre Compose](https://github.com/sargunv/maplibre-compose) - a Compose Multiplatform library to add interactive vector tile maps to your Android and iOS app.
+- [SKAMIR Maps](https://github.com/skamirmaps/skamirmaps) - Kotlin Multiplatform wrapper for MapLibre Native
+
 ### Python
 
 - [py-maplibregl](https://github.com/eodaGmbH/py-maplibregl) - Python bindings for MapLibre GL JS with docs [eodagmbh.github.io/py-maplibregl](https://eodagmbh.github.io/py-maplibregl/) and examples [eodagmbh.github.io/py-maplibregl/examples/road_safety](https://eodagmbh.github.io/py-maplibregl/examples/road_safety/).


### PR DESCRIPTION
Two libraries for working with MapLibre on Compose Multiplatform (like Jetpack Compose but works on additional platforms).

* https://github.com/sargunv/maplibre-compose is mine and published to maven.
* https://github.com/skamirmaps/skamirmaps is **not** mine but it was recently open sourced (not yet published to a package repository to my knowledge).

Unsure if y'all accept submissions not from the author; if not I'm happy to scope this down to just the one that's mine.