### PR TITLE
Add geogrid-maplibre-gl

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [maplibre-contour](https://github.com/onthegomap/maplibre-contour) - Renders contour lines from raster DEM tiles in MapLibre GL JS.
 - [maplibre-gl-dates](https://github.com/OpenHistoricalMap/maplibre-gl-dates/) – Filters a time-enabled map by date. Optimized for OpenHistoricalMap vector tiles.
 - [maplibre-gl-vector-text-protocol](https://github.com/jimmyrocks/maplibre-gl-vector-text-protocol) - Supports `CSV`, `TSV`, `Topojson`, `KML`, `GPX`, and `TCX` formats using the addProtocol feature.
+- [geogrid-maplibre-gl](https://github.com/falseinput/geogrid-maplibre-gl) - Renders customizable graticule (geographic grid).
 
 
 ## Layer Types Plugins


### PR DESCRIPTION
I'd like to propose adding the library for rendering graticule that I wrote: https://github.com/falseinput/geogrid-maplibre-gl

MIT licensed. There's no such plugin yet in the list. The only graticule rendering library that supports both mercator and globe projection 🌐.

Demo: https://codesandbox.io/p/sandbox/wizardly-leavitt-g2cx97