### PR TITLE
add versatiles as tile server

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [Headless Node Renderer](https://github.com/ConservationMetrics/mapgl-tile-renderer) - Headless Node.js MapGL renderer for generating MBTiles with styled raster tiles.
 - [chiitiler](https://github.com/Kanahiro/chiitiler) - chiitiler - "Tiny MapLibre Server" is alternative to Tileserver GL, designed to runs on serverless infrastructures. [demo](https://spatialty-io.github.io/chiitiler-demo/)
 - [TileServer GL](https://github.com/maptiler/tileserver-gl) - Vector tile server from MBTiles archives + server-side rasterizing with MapLibre GL native.
+- [Versatiles](https://versatiles.org/) - A whole toolchain for creating and displaying vecotor maps using the [https://shortbread-tiles.org/schema/](shortbread specification).
 
 ## Utilities
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [Stadia Maps](https://stadiamaps.com/)
 - [TomTom](https://www.tomtom.com/products/maps/)
 - [Tracestrack Maps](https://tracestrack.com/)
+- [Versatiles](https://versatiles.org/) - Free vector tile provider based on the [shortbread](https://shortbread-tiles.org/) specification 
 
 **In bold**: Members of the [MapLibre Sponsorship Program](https://maplibre.org/sponsors/)
 
@@ -249,7 +250,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [Headless Node Renderer](https://github.com/ConservationMetrics/mapgl-tile-renderer) - Headless Node.js MapGL renderer for generating MBTiles with styled raster tiles.
 - [chiitiler](https://github.com/Kanahiro/chiitiler) - chiitiler - "Tiny MapLibre Server" is alternative to Tileserver GL, designed to runs on serverless infrastructures. [demo](https://spatialty-io.github.io/chiitiler-demo/)
 - [TileServer GL](https://github.com/maptiler/tileserver-gl) - Vector tile server from MBTiles archives + server-side rasterizing with MapLibre GL native.
-- [Versatiles](https://versatiles.org/) - A whole toolchain for creating and displaying vecotor maps using the [https://shortbread-tiles.org/schema/](shortbread specification).
+- [Versatiles](https://versatiles.org/) - [Node](https://github.com/versatiles-org/node-versatiles-server) and [Rust](https://github.com/versatiles-org/versatiles-rs) implementation of the versatiles tile server
 
 ## Utilities
 


### PR DESCRIPTION
versatiles is a whole toolchain for creating and displaying vector tiles on the web.

* Create vector tiles via a wrapper for shortbread and tilemaker
* Serving vector tiles via http and their own alternative to `.mbtiles` -> `.versatiles`
* Providing fonts and sprites
* Providing tiles online via their own CDN (you are allowed to use your own CDN in front of them)
* CC-0

https://versatiles.org/