### PR TITLE
Add geojson-map-fit-mercator to Utilities list

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [simplespec-to-gl-style](https://github.com/mapbox/simplespec-to-gl-style) - Converts GeoJSON styles with [simplestyle-spec](https://github.com/mapbox/simplestyle-spec/) to a MapLibre GL Style.
 - [turf](https://turfjs.org/) - provides advanced geospatial analysis tools.
 - [Maperture](https://github.com/stamen/maperture) - A web application for comparing webmap styles.
-- [geojson-map-fit-mercator](https://tristandavey.com/geojson-map-fit-mercator/) - Finds the optimal bearing, zoom and center point for fitting a set of GeoJSON features in a Mapbox GL or MapLibre GL viewport.
+- [geojson-map-fit-mercator](https://github.com/tjdavey/geojson-map-fit-mercator) - Finds the optimal bearing, zoom and center point for fitting a set of GeoJSON features in a Mapbox GL or MapLibre GL viewport. [demo](https://tristandavey.com/geojson-map-fit-mercator/)
 
 ## Development Tools Plugins
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [simplespec-to-gl-style](https://github.com/mapbox/simplespec-to-gl-style) - Converts GeoJSON styles with [simplestyle-spec](https://github.com/mapbox/simplestyle-spec/) to a MapLibre GL Style.
 - [turf](https://turfjs.org/) - provides advanced geospatial analysis tools.
 - [Maperture](https://github.com/stamen/maperture) - A web application for comparing webmap styles.
+- [geojson-map-fit-mercator](https://tristandavey.com/geojson-map-fit-mercator/) - Finds the optimal bearing, zoom and center point for fitting a set of GeoJSON features in a Mapbox GL or MapLibre GL viewport.
 
 ## Development Tools Plugins
 


### PR DESCRIPTION
[geojson-map-fit-mercator](https://tristandavey.com/geojson-map-fit-mercator/) provides an algorithm to optimally fit a set of GeoJSON data inside the viewport providing a MapLibre compatible map center, zoom level and bearing. 