### PR TITLE
Kurviger is using Maplibre

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [Flitsmeister](https://www.flitsmeister.com/) - Navigation app for Android and iOS, with real-time traffic information. Uses MapLibre Native, MapLibre Navigation.
 - [Wynd's](https://wynds.com.au/) - Property research website in Australia with flood risk, bushfire risk and school zone maps built with MapLibre JS.
 - [Ace](https://bdlucas1.github.io/ace) - Free on-course golf scorecard app uses OpenStreetMap data to provide course diagrams, distances, and elevations. Runs entirely in the browser on your mobile phone using MapLibre GL JS.
+- [Kurviger](https://kurviger.com/) - Motorcycle Routeplanning and Navigation app for Android and iOS. Uses MapLibre Native, MapLibre Navigation.
 
 ## Demos / Examples
 


### PR DESCRIPTION
Would be awesome if Kurviger could be added to the list :). We MaplibreNative in both our native apps for [Android](https://play.google.com/store/apps/details?id=com.kurviger.app) and [iOS](https://apps.apple.com/us/app/kurviger-motorcycle-navigation/id6473445827)