### PR TITLE
Add map-gl-style-switcher control for customizable style switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [mapbox-gl-valhalla](https://github.com/watergis/mapbox-gl-valhalla) - Adds a control to provide isochrone features from valhalla server.
 - [mapboxgl-minimap](https://github.com/aesqe/mapboxgl-minimap) - Adds a control to show a miniature overview of the current map.
 - [maplibre-compass-pro](https://github.com/jedluk/maplibre-compass-pro) - old fashioned compass (with compass rose) for Maplibre GL. [demo](https://codesandbox.io/p/sandbox/peaceful-mirzakhani-tv38ck)
+- [map-gl-style-switcher](https://github.com/muimsd/map-gl-style-switcher) - A customizable style switcher control for MapLibre GL JS, also has a `react-map-gl` wrapper.
 - [maplibre-geoman](https://github.com/geoman-io/maplibre-geoman) - Plugin for drawing and editing geometry layers. [demo](https://geoman.io/demo/maplibre)
 - [maplibre-preload](https://github.com/AbelVM/maplibre-preload) - A tiny zero-configuration plugin for preloading tiles and smoothen the experience when using targeted movements in MapLibre GL JS.
 - [maplibre-gl-basemaps](https://github.com/ka7eh/maplibre-gl-basemaps) - A plugin for switching between raster basemaps.


### PR DESCRIPTION
This pull request adds the map-gl-style-switcher control to the User Interface Plugins section.

## What's Added

- **map-gl-style-switcher** - A customizable style switcher control for MapLibre GL JS, also has a `react-map-gl` wrapper.

## Details

- Repository: https://github.com/muimsd/map-gl-style-switcher
- Features: Customizable style switching control for MapLibre GL JS
- Additional: Includes React wrapper for use with react-map-gl
- Added to the User Interface Plugins section in appropriate alphabetical order

This addition follows the format and style of other entries in the awesome-maplibre list.