### PR TITLE
add Vector Tile Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [Ultra](https://overpass-ultra.us/) - A web-based IDE for making maps with MapLibre, supporting a variety of query & file types such as Overpass, ohsome, GeoJSON, KML, and more. [docs](https://overpass-ultra.us/docs)
 - [Libre-studio](https://github.com/BleenIT/libre-studio) - A web-based management layer for Maplibre Martin, allowing the management of map sources, sprites and font glyphs, for ready-to-use custom maps.
 - [Mapforge](https://mapforge.org) - Open Source map vector layer editor with live collaboration and sharing. Uses MapLibre GL JS.
+- [Vector Tile Lab](https://github.com/spider-hand/vector-tile-lab) - An interactive sandbox to tune vector tiles.
 
 ## Users
 


### PR DESCRIPTION
I just published **Vector Tile Lab**, an interactive sandbox tool to tune vector tiles, and added it to the list.  
This project uses MapLibre, so users can try it out instantly with zero config on their local machine.  

[Repo](https://github.com/spider-hand/vector-tile-lab)