### PR TITLE
chore(sec): pin github deps to shas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     name: Spell Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
       - run: wget https://raw.githubusercontent.com/maplibre/maplibre-gl-js/refs/heads/main/.cspell.json


### PR DESCRIPTION
## Launch Checklist

Our CI uses a few actions.
For these actions, we currently just use the mutable GitHub tag.

Since we use Dependabot to update the versions, we should use SHAs.
This makes sure that we are not affected by a certain class of supply chain vulnerability where attackers re-publish bad tags.

Using SHAs matches GitHub recommendations and is a part of the OpenSSFs Scorecard.


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
       ^--- not sure if you want this. Other maintenance actions don't show up as well.