### PR TITLE
Add Gramps Web to Users List

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,9 @@ are designated with a ✅, and hosted projects with a 💙.
 - [Cartes](https://cartes.app) — French alternative to Google Maps based on a fully open source stack
 - [Famxplor](https://famxplor.com/), interactive world map of activities for family vacations, powered by MapLibre with [Svelte MapLibre](https://github.com/dimfeld/svelte-maplibre)
 - [Flitsmeister](https://www.flitsmeister.com/) - Navigation app for Android and iOS, with real-time traffic information. Uses MapLibre Native, MapLibre Navigation.
+- [Gramps Web](https://www.grampsweb.org/) ([Code](https://github.com/gramps-project/gramps-web)) - Modern web app for collaborative genealogy and family history research.<br>
+  Features interactive vector maps with location pins, time filters, and historical map overlays.<br>
+  Migrated from Leaflet to MapLibre GL JS in the [v25.7.0 Release](https://github.com/gramps-project/gramps-web/releases/tag/v25.7.0) for performance reasons.
 - [Herb Atlas](https://herbatlas.fyi) ([Code](https://github.com/tinykite/herb-atlas)) - Collaborative project mapping medicinal herb farms with a focus on sustainable + regenerative practices.
 - [Israel Hiking Map](https://israelhiking.osm.org.il) has maps, route planning, and travel information for Israel. Migrated to [MapLibre](https://github.com/IsraelHikingMap/Site/issues/1532).
 - [Kibana](https://github.com/elastic/kibana#kibana), a browser-based analytics and search dashboard for Elasticsearch has migrated to [MapLibre](https://github.com/elastic/kibana/issues/108742)


### PR DESCRIPTION
This PR adds [Gramps Web](https://www.grampsweb.org/) to the Users section of the awesome-maplibre list.

**What is Gramps Web:**
A modern, free & open source web app for collaborative genealogy and family history research. Fully interoperable with the Gramps desktop application, it enables families to browse and collaboratively edit genealogical databases from any web-enabled device.

**MapLibre Integration:**
Gramps Web migrated from Leaflet to MapLibre GL JS in [v25.7.0](https://github.com/gramps-project/gramps-web/releases/tag/v25.7.0) (July 2025), bringing significant improvements to their mapping features:
- Vector maps for crisp rendering on any screen
- Smoother zooming and panning
- 3D building visualization in cities
- Interactive location pins with time filters
- Support for image overlays and historical maps (OpenHistoricalMap integration)
- Base map using OpenFreeMap vector tiles based on OpenStreetMap

**Changes:**
- Added Gramps Web entry to the Users section
- Alphabetically sorted the Users list (A-Z)

**Links:**
- Website: https://www.grampsweb.org/
- GitHub: https://github.com/gramps-project/gramps-web
- Migration announcement: https://github.com/gramps-project/gramps-web/releases/tag/v25.7.0
- Live demo: https://demo.grampsweb.org/