### PR TITLE
add paddling spots to the users list

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - NZ’s authoritative and open digital [basemap service](https://github.com/linz/basemaps) for LINZ and the public is using [MapLibre](https://github.com/linz/basemaps/pull/1689)
 - [OpenHistoricalMap](https://www.openhistoricalmap.org/) – collaborative project to map the history of the world in detail, powered by MapLibre with maplibre-gl-leaflet
 - [OpenStreetMap Americana Style](https://github.com/osm-americana/openstreetmap-americana#openstreetmap-americana-style) - A quintessentially American map style, powered by [MapLibre](https://github.com/osm-americana/openstreetmap-americana#technology-stack)
+- [Paddling Spots](https://paddlingspots.com) - Platform to share paddle spots, find rentals and explore locations on the map. Uses MapLibre and ngx-maplibre-gl.
 - [Peripleo](https://github.com/britishlibrary/peripleo) - Reusable web map interface with configurable markers, filters, search and more. Open-source and runs on GH pages, all you need is a spreadsheet.
 - [Queering the Map](https://www.queeringthemap.com) ([Code](https://github.com/radical-data/queering-the-map)) - A crowd-sourced platform for anonymously pinning queer experiences on a global map.
 - [SharpMap](https://sharpmap.app/info), ultra-accurate 2D and 3D topographic mountain maps powered by MapLibre.


### PR DESCRIPTION
This PR adds Paddling Spots to the Users section of the awesome-maplibre list.

**What is Paddling Spots?**
A platform to share paddle spots, find rentals and explore new locations on the map. 

**MapLibreIntegration:**
All maps are using MapLibre GL together with the Angular wrapper ngx-maplibre-gl. Using following mapping features

* Map view with spots/rental marker clusters and popups
* Address autocomplete to zoom to locations
* Adding new spots/rentals/hint by selecting a location on a map

**Links:**

* Website: https://paddlingspots.com/