### PR TITLE
Add maplibre-gl-mask-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [maplibre-glass-css](https://github.com/corb555/maplibre-glass-css) - A glass UI theme for standard MapLibre controls.
 - [maplibre-merge-protocol](https://github.com/indus/maplibre-merge-protocol) - A custom protocol for merging geometry with attributes from multiple tilesets in MapLibre. [demo](https://maplibre-merge-protocol.js.org/)
 - [backproj/maplibre-proj](https://github.com/willcohen/backproj) - Display MapLibre maps in any CRS supported by [PROJ](https://proj.org/), using [proj-wasm](https://github.com/willcohen/clj-proj) (PROJ transpiled to WebAssembly). [demo](https://willcohen.github.io/backproj/)
+- [maplibre-gl-mask-plugin](https://codeberg.org/mguihal/maplibre-gl-mask-plugin) - Renders a mask around a geojson feature in MapLibre GL JS. [demo](https://mguihal.codeberg.page/maplibre-gl-mask-plugin)
 
 ## Layer Types Plugins
 


### PR DESCRIPTION
Adding maplibre-gl-mask-plugin, a MapLibre GL JS plugin to render a mask around geojson features.

Repository : https://codeberg.org/mguihal/maplibre-gl-mask-plugin
Demo : https://mguihal.codeberg.page/maplibre-gl-mask-plugin