### PR TITLE
Add GroundwaterCast UK to Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [Gramps Web](https://www.grampsweb.org/) ([Code](https://github.com/gramps-project/gramps-web)) - Modern web app for collaborative genealogy and family history research.<br>
   Features interactive vector maps with location pins, time filters, and historical map overlays.<br>
   Migrated from Leaflet to MapLibre GL JS in the [v25.7.0 Release](https://github.com/gramps-project/gramps-web/releases/tag/v25.7.0) for performance reasons.
+- [GroundwaterCast UK](https://groundwatercast.com) ([Code](https://github.com/dominicm2023/groundwatercast-uk)) - Daily probabilistic groundwater forecasts for 1,300+ monitored boreholes in England, built entirely on open data. Uses MapLibre GL JS for the national borehole explorer and landing-page map.
 - [Herb Atlas](https://herbatlas.fyi) ([Code](https://github.com/tinykite/herb-atlas)) - Collaborative project mapping medicinal herb farms with a focus on sustainable + regenerative practices.
 - [Hory.app](https://hory.app) — Web/iOS/Android app for logging mountain summit visits, backed by a database of 350,000+ mountains worldwide. Uses MapLibre GL JS for online and offline maps.
 - [Israel Hiking Map](https://israelhiking.osm.org.il) has maps, route planning, and travel information for Israel.


### PR DESCRIPTION
Adds [GroundwaterCast UK](https://groundwatercast.com) to the Users section (alphabetical position kept): daily probabilistic groundwater forecasts for 1,300+ monitored boreholes in England, built entirely on open data. MapLibre GL JS powers the national borehole explorer and the landing-page snapshot map (with OpenFreeMap tiles). Source: https://github.com/dominicm2023/groundwatercast-uk (MIT).