### PR TITLE
Add Seascape to Map/Tile Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [OpenFreeMap](https://openfreemap.org/)
 - [OSM Americana Community Vector Tile Server](https://tile.ourmap.us/)
 - [Protomaps](https://protomaps.com/)
+- [Seascape](https://openwaters.io/charts/seascape) - Open source global bathymetry tiles with a ready-made nautical style.
 - [Stadia Maps](https://stadiamaps.com/)
 - [TomTom](https://www.tomtom.com/products/maps/)
 - [Tuiles en Liberté](https://tuiles.enliberte.fr/)


### PR DESCRIPTION
Seascape is a free, keyless bathymetry tile endpoint (raster-dem and vector) for MapLibre, built from 23 global and regional open sources, with a served style.json and TileJSON for both tile sets. BSD-3 pipeline, CC BY 4.0 tiles. Disclosure: I'm the author.