### PR TITLE
Add Castlemap to Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ are designated with a ✅, and hosted projects with a 💙.
 
 - [Ace](https://bdlucas1.github.io/ace) - Free on-course golf scorecard app uses OpenStreetMap data to provide course diagrams, distances, and elevations. Runs entirely in the browser on your mobile phone using MapLibre GL JS.
 - [Cartes](https://cartes.app) — French alternative to Google Maps based on a fully open source stack
+- [Castlemap](https://thecastlemap.com) - Interactive night-map of 2,400 castles, fortresses and palaces across 131 countries, generated from Wikidata. Built with MapLibre GL JS on OpenFreeMap tiles; free castle dataset as GeoJSON/CSV.
 - [Climate Action Navigator](https://climate-action.heigit.org/) - Interactive dashboard that translates high-resolution geospatial data into neighborhood-level insights for targeted urban climate action.
 - [Famxplor](https://famxplor.com/), interactive world map of activities for family vacations, powered by MapLibre with [Svelte MapLibre](https://github.com/dimfeld/svelte-maplibre)
 - [Flitsmeister](https://www.flitsmeister.com/) - Navigation app for Android and iOS, with real-time traffic information. Uses MapLibre Native, MapLibre Navigation.


### PR DESCRIPTION
Adds Castlemap (https://thecastlemap.com) to the Users section — a free interactive night-map of 2,400 castles, fortresses and palaces across 131 countries, generated from Wikidata. Built with MapLibre GL JS on OpenFreeMap vector tiles; no accounts, no ads, and the curated dataset is a free GeoJSON/CSV download.