### PR TITLE
Add maplibre-label-callout plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [maplibre-pegman](https://github.com/rezw4n/maplibre-pegman) - Plugin that integrates Google Street View into any MapLibre map.
 - [maplibre-transition](https://github.com/popkinj/maplibre-transition) - A plugin for smooth transitions between map styles. [demo](https://observablehq.com/d/b9a97acdf712a77b)
 - [maplibre-gl-layers-control](https://github.com/mvt-proj/maplibre-gl-layers-control) - It allows to show/hide layers, opacity control and integration with legends.
+- [maplibre-label-callout](https://github.com/leoneljdias/maplibre-label-callout) - Labels with connector lines for MapLibre GL JS. [demo](https://leoneljdias.github.io/maplibre-label-callout/demo/) · [npm](https://www.npmjs.com/package/@leoneljdias/maplibre-label-callout)
 - [maplibre-ui-translations](https://github.com/spwoodcock/maplibre-ui-translations) - Community translations for the default MapLibre UI.
 
 ## Geocoding & Search Plugins


### PR DESCRIPTION
Adds [maplibre-label-callout](https://github.com/leoneljdias/maplibre-label-callout) - a MapLibre GL JS plugin for labels with connector lines.

- [x] Plugin is functional with a live [demo](https://leoneljdias.github.io/maplibre-label-callout/demo/)
- [x] Published on [npm](https://www.npmjs.com/package/@leoneljdias/maplibre-label-callout)
- [x] Listed under User Interface Plugins (alphabetical order)