### PR TITLE
Add Grundradar to Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ are designated with a ✅, and hosted projects with a 💙.
   Features interactive vector maps with location pins, time filters, and historical map overlays.<br>
   Migrated from Leaflet to MapLibre GL JS in the [v25.7.0 Release](https://github.com/gramps-project/gramps-web/releases/tag/v25.7.0) for performance reasons.
 - [GroundwaterCast UK](https://groundwatercast.com) ([Code](https://github.com/dominicm2023/groundwatercast-uk)) - Daily probabilistic groundwater forecasts for 1,300+ monitored boreholes in England, built entirely on open data. Uses MapLibre GL JS for the national borehole explorer and landing-page map.
+- [Grundradar](https://grundradar.de/) - Free German land-parcel due-diligence tool using MapLibre GL JS to combine cadastral context, official land values, planning constraints, and environmental risk checks from public data.
 - [Herb Atlas](https://herbatlas.fyi) ([Code](https://github.com/tinykite/herb-atlas)) - Collaborative project mapping medicinal herb farms with a focus on sustainable + regenerative practices.
 - [Hory.app](https://hory.app) — Web/iOS/Android app for logging mountain summit visits, backed by a database of 350,000+ mountains worldwide. Uses MapLibre GL JS for online and offline maps.
 - [Israel Hiking Map](https://israelhiking.osm.org.il) has maps, route planning, and travel information for Israel.


### PR DESCRIPTION
Adds [Grundradar](https://grundradar.de/) to the Users section. Grundradar is a free Germany-focused land-parcel due-diligence tool whose parcel and result maps use MapLibre GL JS for official land values, planning context, and environmental-risk layers.

Disclosure: I work on Grundradar.