### PR TITLE
Add @honua/sdk-js to Utility Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ are designated with a ✅, and hosted projects with a 💙.
 
 ## Utility Libraries
 
+- [@honua/sdk-js](https://github.com/honua-io/honua-sdk-js) - Typed multi-protocol data client for MapLibre: query ArcGIS/Esri GeoServices, OGC API, WFS, WMS, OData, and GeoParquet services and mount results as MapLibre sources, plus an ArcGIS-to-MapLibre migration codemod. [demo](https://honua-io.github.io/honua-sdk-js/guides/quickstart.html)
 - [expression-jamsession](https://github.com/mapbox/expression-jamsession/) - Converts [Mapbox Studio formulas](https://www.mapbox.com/help/studio-manual-styles/#use-a-formula) into [expressions](https://maplibre.org/maplibre-style-spec/expressions/).
 - [mapbox-choropleth](https://github.com/stevage/mapbox-choropleth) - Create a choropleth layer from a CSV source and a geometry source.
 - [mapbox-gl-layer-groups](https://github.com/mapbox/mapbox-gl-layer-groups) - Manages layer groups.


### PR DESCRIPTION
Adds `@honua/sdk-js` to Utility Libraries, inside the JavaScript plugins block used by the MapLibre GL JS plugins page.

Honua is an Apache-2.0 TypeScript data and service client that uses MapLibre for rendering. It provides one typed query contract across ArcGIS/Esri GeoServices, OGC API, WFS, WMS/WMTS, STAC, OData, and GeoParquet, plus MapLibre source/layer mounting helpers and an ArcGIS-to-MapLibre migration codemod.

The linked [quickstart](https://honua-io.github.io/honua-sdk-js/guides/quickstart.html) is published from the SDK repository and kept green by its browser smoke lane.

Validation:

- one Markdown entry in the existing Utility Libraries format
- repository and demo links return HTTP 200
- upstream SDK CI and docs workflows are green on trunk

Tracks honua-io/honua-sdk-js#499.
