### PR TITLE
fix: update Room TBA URL to room-tba.uplb.tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - Plantaube (https://plantaube.com) – A free Webtool to create custom urban maps and site plans out of OSM-data. Optimized for Urban Planners and Architects.
 - [Queering the Map](https://www.queeringthemap.com) ([Code](https://github.com/radical-data/queering-the-map)) - A crowd-sourced platform for anonymously pinning queer experiences on a global map.
 - [Radatlas](https://radatlas.at) - Every named cycle route in Austria on one map, with stages, elevation profiles and GPX/TCX downloads. Geometry from OpenStreetMap, terrain and base map from Austrian open government data. Built with MapLibre GL JS and PMTiles; the pitched 3D view can be flattened for riders it makes queasy, and the site meets WCAG 2.2 AA.
-- [Room TBA](https://room-tba.uplbtools.me) ([Code](https://github.com/uplbtools/room-tba)) - Open-source campus room finder for a Philippine university with MapLibre GL JS, class schedules, transit routes, and offline PWA sync via PGlite.
+- [Room TBA](https://room-tba.uplb.tools) ([Code](https://github.com/uplbtools/room-tba)) - Open-source campus room finder for a Philippine university with MapLibre GL JS, class schedules, transit routes, and offline PWA sync via PGlite.
 - [SharpMap](https://sharpmap.app/info), ultra-accurate 2D and 3D topographic mountain maps powered by MapLibre.
 - [StreetComplete](https://streetcomplete.app) — Easy to use mobile OpenStreetMap editor used for mapping in the field
 - [TatraMap.eu](https://tatramap.eu/#/teren-3d), a 3D map of Tatra Mountains powered by MapLibre.


### PR DESCRIPTION
## Summary
- Room TBA moved from `room-tba.uplbtools.me` to `room-tba.uplb.tools`.
- Entry text unchanged; link only.

## Test plan
- [ ] Open https://room-tba.uplb.tools and confirm it loads
- [ ] Confirm no other README lines were edited