### PR TITLE
Add Seamap to Map/Tile Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [OpenFreeMap](https://openfreemap.org/)
 - [OSM Americana Community Vector Tile Server](https://tile.ourmap.us/)
 - [Protomaps](https://protomaps.com/)
+- [Seamap](https://openwaters.io/charts/seamap) - Open source nautical chart tiles and MapLibre style, rendered weekly from OpenStreetMap seamark data.
 - [Seascape](https://openwaters.io/charts/seascape) - Open source global bathymetry tiles with a ready-made nautical style.
 - [Stadia Maps](https://stadiamaps.com/)
 - [TomTom](https://www.tomtom.com/products/maps/)


### PR DESCRIPTION
Seamap is a nautical chart style served as free vector tiles with a ready-made MapLibre style: seamarks rendered from OpenStreetMap, plus depth shading and contours from open bathymetry. No API key, CC BY 4.0.

The chart layers are also published as [@openwaters/seamap](https://www.npmjs.com/package/@openwaters/seamap), for composing into a style of your own.

Source: https://github.com/openwatersio/seamap
