### PR TITLE
Refresh three Users entries, one of which names a site that no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,10 +313,10 @@ are designated with a ✅, and hosted projects with a 💙.
 
 - [Ace](https://bdlucas1.github.io/ace) - Free on-course golf scorecard app uses OpenStreetMap data to provide course diagrams, distances, and elevations. Runs entirely in the browser on your mobile phone using MapLibre GL JS.
 - [Cartes](https://cartes.app) — French alternative to Google Maps based on a fully open source stack
-- [Castlemap](https://thecastlemap.com) - Interactive night-map of 7,044 castles, fortresses and palaces across 141 countries, generated from Wikidata. Built with MapLibre GL JS on OpenFreeMap tiles; free castle dataset as GeoJSON/CSV.
+- [Castlemap](https://thecastlemap.com) - Interactive night-map of thousands of castles, fortresses and palaces worldwide, generated from Wikidata. Built with MapLibre GL JS on OpenFreeMap tiles; free castle dataset as GeoJSON/CSV.
 - [Climate Action Navigator](https://climate-action.heigit.org/) - Interactive dashboard that translates high-resolution geospatial data into neighborhood-level insights for targeted urban climate action.
 - [Famxplor](https://famxplor.com/), interactive world map of activities for family vacations, powered by MapLibre with [Svelte MapLibre](https://github.com/dimfeld/svelte-maplibre)
-- [FilmMap](https://thefilmmap.com) - Interactive night-map of 15,272 real filming locations across 161 countries, joined to the 12,762 films, series, games, anime and manga recorded at them. Every pin is a Wikidata "filming location" statement, so each links back to its source; games and anime are placed instead by where they are set, because neither is filmed anywhere, and the two claims are never mixed. Built with MapLibre GL JS on OpenFreeMap tiles.
+- [FilmMap](https://thefilmmap.com) - Interactive night-map of thousands of real filming locations worldwide, joined to the films, series, games, anime and manga recorded at them. Every pin is a Wikidata "filming location" statement, so each links back to its source; games and anime are placed instead by where they are set, because neither is filmed anywhere, and the two claims are never mixed. Built with MapLibre GL JS on OpenFreeMap tiles.
 - [Flitsmeister](https://www.flitsmeister.com/) - Navigation app for Android and iOS, with real-time traffic information. Uses MapLibre Native, MapLibre Navigation.
 - [Gramps Web](https://www.grampsweb.org/) ([Code](https://github.com/gramps-project/gramps-web)) - Modern web app for collaborative genealogy and family history research.<br>
   Features interactive vector maps with location pins, time filters, and historical map overlays.<br>
@@ -354,7 +354,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [Utopia Map](https://github.com/utopia-os/utopia-map) - Collaborative map-based app for decentralized coordination and real-life networking.<br>
   Built with MapLibre GL JS, it enables communities to create custom map instances with interactive layers for managing members, activities, and resources.
 - [Vremenar Weather](https://vremenar.tano.si), a cross-platform app to display weather conditions and forecast on a map. Using MapLibre Native.
-- [World Train Map](https://worldtrainmap.com) - Interactive atlas of 1,288 notable train routes across 120 countries, colour-coded by type on OpenFreeMap tiles. Built with MapLibre GL JS; free rail dataset as GeoJSON/CSV.
+- [World Train Map](https://worldtrainmap.com) - Interactive atlas of over a thousand notable train routes worldwide, colour-coded by type on OpenFreeMap tiles. Built with MapLibre GL JS; free rail dataset as GeoJSON/CSV.
 - [Wynd's](https://wynds.com.au/) - Property research website in Australia with flood risk, bushfire risk and school zone maps built with MapLibre JS.
 - [Zornade](https://app.zornade.com) - Italian cadastral parcel intelligence platform aggregating 15+ public data sources (hydrogeological risk, real estate prices, demographics) into a per-parcel profile covering 85 million cadastral parcels, with a free REST API. Uses MapLibre GL JS.
 

--- a/README.md
+++ b/README.md
@@ -313,10 +313,10 @@ are designated with a ✅, and hosted projects with a 💙.
 
 - [Ace](https://bdlucas1.github.io/ace) - Free on-course golf scorecard app uses OpenStreetMap data to provide course diagrams, distances, and elevations. Runs entirely in the browser on your mobile phone using MapLibre GL JS.
 - [Cartes](https://cartes.app) — French alternative to Google Maps based on a fully open source stack
-- [Castlemap](https://thecastlemap.com) - Interactive night-map of 2,400 castles, fortresses and palaces across 131 countries, generated from Wikidata. Built with MapLibre GL JS on OpenFreeMap tiles; free castle dataset as GeoJSON/CSV.
+- [Castlemap](https://thecastlemap.com) - Interactive night-map of 7,044 castles, fortresses and palaces across 141 countries, generated from Wikidata. Built with MapLibre GL JS on OpenFreeMap tiles; free castle dataset as GeoJSON/CSV.
 - [Climate Action Navigator](https://climate-action.heigit.org/) - Interactive dashboard that translates high-resolution geospatial data into neighborhood-level insights for targeted urban climate action.
 - [Famxplor](https://famxplor.com/), interactive world map of activities for family vacations, powered by MapLibre with [Svelte MapLibre](https://github.com/dimfeld/svelte-maplibre)
-- [FilmMap](https://thefilmmap.com) - Interactive night-map of 14,503 real filming locations across 160 countries, joined to the 12,634 films, series, games, anime and manga recorded at them. Every pin is a Wikidata "filming location" statement, so each links back to its source; games and anime are placed instead by where they are set, because neither is filmed anywhere, and the two claims are never mixed. Built with MapLibre GL JS on OpenFreeMap tiles.
+- [FilmMap](https://thefilmmap.com) - Interactive night-map of 15,272 real filming locations across 161 countries, joined to the 12,762 films, series, games, anime and manga recorded at them. Every pin is a Wikidata "filming location" statement, so each links back to its source; games and anime are placed instead by where they are set, because neither is filmed anywhere, and the two claims are never mixed. Built with MapLibre GL JS on OpenFreeMap tiles.
 - [Flitsmeister](https://www.flitsmeister.com/) - Navigation app for Android and iOS, with real-time traffic information. Uses MapLibre Native, MapLibre Navigation.
 - [Gramps Web](https://www.grampsweb.org/) ([Code](https://github.com/gramps-project/gramps-web)) - Modern web app for collaborative genealogy and family history research.<br>
   Features interactive vector maps with location pins, time filters, and historical map overlays.<br>
@@ -350,11 +350,11 @@ are designated with a ✅, and hosted projects with a 💙.
 - [StreetComplete](https://streetcomplete.app) — Easy to use mobile OpenStreetMap editor used for mapping in the field
 - [TatraMap.eu](https://tatramap.eu/#/teren-3d), a 3D map of Tatra Mountains powered by MapLibre.
 - [The Wikipedia app for Android](https://github.com/wikimedia/apps-android-wikipedia) uses to display articles with coordinates.
-- [Trainrouter](https://trainrouter.com) - Interactive atlas of 767 notable train routes across 118 countries, colour-coded by type on OpenFreeMap tiles. Built with MapLibre GL JS; free rail dataset as GeoJSON/CSV.
 - [TravelerMap.net](http://travelermap.net), a website which allows to explore National Parks
 - [Utopia Map](https://github.com/utopia-os/utopia-map) - Collaborative map-based app for decentralized coordination and real-life networking.<br>
   Built with MapLibre GL JS, it enables communities to create custom map instances with interactive layers for managing members, activities, and resources.
 - [Vremenar Weather](https://vremenar.tano.si), a cross-platform app to display weather conditions and forecast on a map. Using MapLibre Native.
+- [World Train Map](https://worldtrainmap.com) - Interactive atlas of 1,288 notable train routes across 120 countries, colour-coded by type on OpenFreeMap tiles. Built with MapLibre GL JS; free rail dataset as GeoJSON/CSV.
 - [Wynd's](https://wynds.com.au/) - Property research website in Australia with flood risk, bushfire risk and school zone maps built with MapLibre JS.
 - [Zornade](https://app.zornade.com) - Italian cadastral parcel intelligence platform aggregating 15+ public data sources (hydrogeological risk, real estate prices, demographics) into a per-parcel profile covering 85 million cadastral parcels, with a free REST API. Uses MapLibre GL JS.
 


### PR DESCRIPTION
Housekeeping on three entries I maintain. Every number below was read off the live site today.

- **Castlemap** — 2,400 → 7,044 landmarks, 131 → 141 countries.
- **FilmMap** — 14,503 → 15,272 locations, 160 → 161 countries, 12,634 → 12,762 productions.
- **Trainrouter → World Train Map** — the site was renamed and moved to `worldtrainmap.com` on 11 August, and its atlas has grown from 767 routes across 118 countries to 1,288 across 120. The old domain still 301s, so the entry was not broken, only wrong. The renamed entry moves a few lines up to keep the list alphabetical.

Three lines changed, nothing else.