### PR TITLE
Add GeoLens to Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [Famxplor](https://famxplor.com/), interactive world map of activities for family vacations, powered by MapLibre with [Svelte MapLibre](https://github.com/dimfeld/svelte-maplibre)
 - [FilmMap](https://thefilmmap.com) - Interactive night-map of 14,503 real filming locations across 160 countries, joined to the 12,634 films, series, games, anime and manga recorded at them. Every pin is a Wikidata "filming location" statement, so each links back to its source; games and anime are placed instead by where they are set, because neither is filmed anywhere, and the two claims are never mixed. Built with MapLibre GL JS on OpenFreeMap tiles.
 - [Flitsmeister](https://www.flitsmeister.com/) - Navigation app for Android and iOS, with real-time traffic information. Uses MapLibre Native, MapLibre Navigation.
+- [GeoLens](https://github.com/geolens-io/geolens) - Self-hosted geospatial catalog and map builder. Map editing and shared maps run on MapLibre GL JS. [demo](https://demo.getgeolens.com)
 - [Gramps Web](https://www.grampsweb.org/) ([Code](https://github.com/gramps-project/gramps-web)) - Modern web app for collaborative genealogy and family history research.<br>
   Features interactive vector maps with location pins, time filters, and historical map overlays.<br>
   Migrated from Leaflet to MapLibre GL JS in the [v25.7.0 Release](https://github.com/gramps-project/gramps-web/releases/tag/v25.7.0) for performance reasons.


### PR DESCRIPTION
Adds GeoLens to the Users section. The map builder and shared map views run on MapLibre GL JS. Apache-2.0, live demo: https://demo.getgeolens.com

Disclosure: I'm the author.