### PR TITLE
Add MerryMap to Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [Mapeak](https://mapeak.com) - a world wide navigation app that supports open data by uploading images to wikimedia and data to OSM. It has the fastest known map updates with offline maps which are updated on a daily bases and online maps that updates 3 times a day. It has planning capabilities, search and everything you need to enjoy the outdoors!
 - [MapLibre Storytelling](https://github.com/digidem/maplibre-storymap) - a storytelling template using MapLibre GL JS which can be hosted as static HTML or using Node.
 - [Mappi Studio](https://mappi.studio) - An online map animation creator. Create cinematic travel routes, fly-over animations, and 4K map videos in your browser.
+- [MerryMap](https://merrymap.co) - Crowd-sourced map of neighborhood Christmas-light displays across ten US metros, with a browsable city guide per metro. Built with MapLibre GL JS on OpenFreeMap tiles, runtime-restyled dark for night viewing.
 - [Mountaya](https://mountaya.com) - Interactive 3D maps to understand, explore, and stay safe in the mountain.
 - [Namazue Console](https://github.com/Hybirdss/namazue-console) - Japan-wide earthquake intelligence console with seismic intensity modeling, infrastructure impact assessment, and real-time P/S wave propagation. Built with MapLibre GL JS 5 + deck.gl 9. [demo](https://namazue.dev)
 - [On The Go Map](https://onthegomap.com) - A website for planning running and biking routes. Migrated to MapLibre


### PR DESCRIPTION
MerryMap is a free, mobile-first map of neighborhood Christmas-light displays, currently covering ten US metros with a static city guide per metro.

It uses MapLibre GL JS with OpenFreeMap tiles, restyled at runtime to a dark palette for night viewing.

Site: https://merrymap.co
Map: https://merrymap.co/map

Added under Users in alphabetical order.