### PR TITLE
Add veritiles to Layer Types Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [ol-maplibre-layer](https://github.com/geoblocks/ol-maplibre-layer) - Render a MapLibre GL JS map as an [OpenLayers](https://openlayers.org/) layer.
 - [PMTiles for MapLibre](https://github.com/protomaps/PMTiles/tree/main/js) - A library that uses addProtocol to read PMTIles. a single-file format for hosting tilesets without a server or API, just S3 or other storage providers.
 - [@naivemap/maplibre-gl-image-layer](https://www.naivemap.com/map-gl-layers/api/maplibre-gl-image-layer/) - A versatile layer for displaying georeferenced images with various projections (using proj4js) on the map.
+- [veritiles](https://github.com/guillaumemichel/veritiles) - Verified [PMTiles](https://github.com/protomaps/PMTiles) from untrusted static hosting [demo](https://guillaumemichel.github.io/ipfs-pmtiles-demo/)
 
 ## Utility Libraries
 


### PR DESCRIPTION
`veritiles` is a zero-dependency drop-in `Source` for the standard [pmtiles](https://github.com/protomaps/PMTiles/tree/main/js) protocol: it fetches byte ranges from any plain HTTP host (a CDN, a bucket, GitHub Pages) and cryptographically verifies every byte against a single root of trust (a CID) before the map renders it. It works with MapLibre GL via `addProtocol`, the same way as the existing "PMTiles for MapLibre" entry it sits next to.

See [example](https://github.com/guillaumemichel/veritiles/blob/f7d6e30beb136eb6ebca401622fea6c3fd7f078f/examples/maplibre.html) and [demo](https://guillaumemichel.github.io/ipfs-pmtiles-demo/)