### PR TITLE
Add MTL Explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ are designated with a ✅, and hosted projects with a 💙.
 - [Mappi Studio](https://mappi.studio) - An online map animation creator. Create cinematic travel routes, fly-over animations, and 4K map videos in your browser.
 - [MerryMap](https://merrymap.co) - Crowd-sourced map of neighborhood Christmas-light displays across ten US metros, with a browsable city guide per metro. Built with MapLibre GL JS on OpenFreeMap tiles, runtime-restyled dark for night viewing.
 - [Mountaya](https://mountaya.com) - Interactive 3D maps to understand, explore, and stay safe in the mountain.
+- [MTL Explorer](https://github.com/mindalyze-com/mtl-explorer) ([demo](https://mtl-demo.mindalyze.com/mtl/)) - A self-hosted GPS track archive that uses MapLibre GL JS for 2D and 3D map exploration, activity replay, track analysis, and route planning.
 - [Namazue Console](https://github.com/Hybirdss/namazue-console) - Japan-wide earthquake intelligence console with seismic intensity modeling, infrastructure impact assessment, and real-time P/S wave propagation. Built with MapLibre GL JS 5 + deck.gl 9. [demo](https://namazue.dev)
 - [On The Go Map](https://onthegomap.com) - A website for planning running and biking routes. Migrated to MapLibre
 - [Pharos AI](https://conflicts.app) - Open-source real-time intelligence dashboard for geopolitical conflict tracking with interactive MapLibre-based geospatial visualization. ([Source Code](https://github.com/Juliusolsson05/pharos-ai))


### PR DESCRIPTION
Adds MTL Explorer to the Users section, with links to the source repository and live demo. MTL Explorer is a self-hosted GPS track archive that uses MapLibre GL JS for 2D and 3D map exploration, activity replay, track analysis, and route planning.